### PR TITLE
Make yamllint less strict

### DIFF
--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -146,7 +146,7 @@ function checks (config) {
              * @return {Array}
              */
             function (config) {
-                return createQaJobs('yamllint mkdocs.yml', config);
+                return createQaJobs('yamllint -d relaxed --no-warnings mkdocs.yml', config);
             }
         ),
         new Check(


### PR DESCRIPTION
- Use the "relaxed" configuration set (which makes most errors warnings, and, in particular, line lengths and missing document-start).
- Do not exit with a non-zero status when only warnings, but no errors, occur.
